### PR TITLE
Add configuration-driven agentic framework scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,88 @@
-# agnostic-agent-framework
-Config-driven agentic AI framework using IBM Granite, watsonx, and Qiskit. Includes tool registry (HTTP, SQL, RAG, Quantum), orchestration loop, and evaluation harness for domain-agnostic prototypes.
+# Agnostic Agent Framework
+
+A minimal-yet-complete scaffold for building agentic workflows. The project
+ships with a configuration driven planner → executor → reflector loop, an
+extensible tool registry, and deterministic fixtures for testing.
+
+## Features
+
+- **Model/provider agnostic.** Configuration specifies the LLM provider,
+  model, and parameters without code changes.
+- **Config-driven orchestration.** Plans and tool wiring live in YAML, making it
+  easy to swap domains or experiment with new flows.
+- **Tool-centric execution.** Built-in HTTP, SQL, RAG, and Quantum tools
+  demonstrate how to compose external capabilities while keeping tests fast.
+- **LangGraph-style loop.** Planner emits a step list, executor streams through
+  tools, and the reflector summarises the run for evaluation or logging.
+- **Observability aware.** Execution captures per-step timings for lightweight
+  performance tracking.
+- **Fully tested.** The repository includes a unittest harness and fixture
+  configuration for deterministic validation.
+
+## Quick start
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Review or edit `config.yaml` to describe your domain. Tool definitions accept
+   fully-qualified class paths and optional constructor arguments.
+
+3. Run an agent loop:
+
+   ```bash
+   python -m agentic_framework.examples.sql
+   ```
+
+   Each example points at the sample fixture configuration to keep output
+   deterministic. Swap in your own configuration path for real workloads.
+
+4. Execute the full test suite:
+
+   ```bash
+   python -m unittest discover -s agentic_framework/tests
+   ```
+
+## Configuration shape
+
+```yaml
+agent:
+  name: Iron Dillo Agent
+  llm:
+    provider: ibm
+    model: granite-13b-chat-v2
+    parameters:
+      temperature: 0.1
+  tools:
+    - http
+    - sql
+    - rag
+    - quantum
+  plan:
+    - tool: http
+      args:
+        url: "/status"
+    - tool: sql
+      args:
+        query: "SELECT name FROM users"
+```
+
+Each tool referenced in `plan` must have a matching entry under `tools`. The
+framework resolves the class dynamically and caches the instance across steps.
+
+## Adding new tools
+
+1. Implement a subclass of `BaseTool` with an `execute` method.
+2. Expose it via a fully-qualified path (for example
+   `my_package.tools.CustomTool`).
+3. Update the YAML configuration with the tool definition and any constructor
+   arguments.
+
+The executor will automatically resolve the class the next time a plan step
+references the tool.
+
+## License
+
+Apache 2.0. See [LICENSE](LICENSE) for details.

--- a/agentic_framework/__init__.py
+++ b/agentic_framework/__init__.py
@@ -1,0 +1,36 @@
+"""Top-level package for the agentic framework scaffold.
+
+The package exposes the primary objects that make up the orchestration loop so
+consumers can compose the framework without digging through individual modules.
+"""
+
+from .agent import Agent
+from .config import Config, load_config
+from .executor import Executor
+from .planner import Planner
+from .reflect import Reflector
+from .tools import (
+    BaseTool,
+    HTTPTool,
+    QuantumTool,
+    RAGTool,
+    SQLTool,
+    ToolRegistry,
+    get_tool,
+)
+
+__all__ = [
+    "Agent",
+    "Config",
+    "Executor",
+    "Planner",
+    "Reflector",
+    "BaseTool",
+    "HTTPTool",
+    "QuantumTool",
+    "RAGTool",
+    "SQLTool",
+    "ToolRegistry",
+    "get_tool",
+    "load_config",
+]

--- a/agentic_framework/agent.py
+++ b/agentic_framework/agent.py
@@ -1,0 +1,36 @@
+"""Agent orchestrator tying together planning, execution, and reflection."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .config import Config
+from .executor import Executor
+from .planner import Planner
+from .reflect import Reflector
+
+
+class Agent:
+    """High-level façade for the agentic workflow."""
+
+    def __init__(self, config_file: Any):
+        self.config = Config(config_file)
+        self.planner = Planner(self.config)
+        self.executor = Executor(self.config)
+        self.reflector = Reflector(self.config)
+
+    def run(self, goal: Optional[str] = None) -> Dict[str, Any]:
+        """Run the planner → executor → reflector loop.
+
+        Parameters
+        ----------
+        goal:
+            Optional textual goal that can be used by the planner. The default
+            planner in this scaffold does not use it directly but passing it
+            through demonstrates the API surface for custom planners.
+        """
+
+        plan = self.planner.generate_plan(goal=goal)
+        results = self.executor.execute(plan)
+        reflection = self.reflector.reflect_on_execution(plan, results)
+        return {"plan": plan, "results": results, "reflection": reflection}

--- a/agentic_framework/config.py
+++ b/agentic_framework/config.py
@@ -1,0 +1,241 @@
+"""Configuration loading utilities for the agentic framework."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - fallback parser is exercised in tests
+    yaml = None
+
+
+@dataclass(frozen=True)
+class LLMConfig:
+    """Metadata for the large language model backing the agent."""
+
+    provider: str
+    model: str
+    parameters: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AgentSettings:
+    """Agent-specific configuration derived from the YAML file."""
+
+    name: str
+    llm: LLMConfig
+    tools: Iterable[str]
+    plan: List[Mapping[str, Any]] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ToolSettings:
+    """Definition for a tool registered in the framework."""
+
+    class_path: str
+    args: Mapping[str, Any] = field(default_factory=dict)
+
+
+def load_config(config_file: Any) -> Dict[str, Any]:
+    """Load a YAML configuration file and return the parsed dictionary."""
+
+    path = Path(config_file)
+    if not path.exists():
+        raise FileNotFoundError(f"Config file '{path}' does not exist")
+
+    with path.open("r", encoding="utf-8") as handle:
+        text = handle.read()
+
+    if yaml is not None:  # pragma: no cover - exercised when PyYAML is available
+        data = yaml.safe_load(text) or {}
+    else:
+        data = _load_simple_yaml(text)
+
+    if not isinstance(data, MutableMapping):
+        raise ValueError("Configuration must be a mapping at the top level")
+    return dict(data)
+
+
+def _load_simple_yaml(text: str) -> Dict[str, Any]:
+    """Parse a minimal subset of YAML supporting mappings and sequences."""
+
+    lines = [line.rstrip() for line in text.splitlines() if line.strip() and not line.strip().startswith("#")]
+    processed: List[str] = []
+    for line in lines:
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+        if stripped.startswith("- ") and ":" in stripped[2:]:
+            processed.append(" " * indent + "-")
+            processed.append(" " * (indent + 2) + stripped[2:])
+        else:
+            processed.append(line)
+    return _parse_block(processed, 0, 0)[0]
+
+
+def _parse_block(lines: List[str], indent: int, index: int) -> Any:
+    container: Any = None
+    items_list: List[Any] = []
+    items_map: Dict[str, Any] = {}
+
+    while index < len(lines):
+        line = lines[index]
+        stripped = line.lstrip()
+        current_indent = len(line) - len(stripped)
+        if current_indent < indent:
+            break
+        if current_indent > indent:
+            raise ValueError(f"Unexpected indentation at line: {line}")
+
+        if stripped.startswith("-"):
+            if container is None:
+                container = []
+            elif not isinstance(container, list):
+                raise ValueError("Cannot mix list and mapping entries")
+            value_part = stripped[1:].strip()
+            if value_part:
+                items_list.append(_parse_scalar(value_part))
+                index += 1
+                continue
+            item, index = _parse_block(lines, indent + 2, index + 1)
+            items_list.append(item)
+        else:
+            if container is None:
+                container = {}
+            elif not isinstance(container, dict):
+                raise ValueError("Cannot mix list and mapping entries")
+            if ":" not in stripped:
+                raise ValueError(f"Expected ':' in mapping line: {line}")
+            key, value_part = _split_key_value(stripped)
+            key = _parse_key(key)
+            value_part = value_part.strip()
+            if not key:
+                raise ValueError("Empty key in mapping entry")
+            if value_part:
+                items_map[key] = _parse_scalar(value_part)
+                index += 1
+            else:
+                value, index = _parse_block(lines, indent + 2, index + 1)
+                items_map[key] = value
+    if container is None:
+        return {}, index
+    if isinstance(container, list):
+        return items_list, index
+    return items_map, index
+
+
+def _parse_scalar(token: str) -> Any:
+    if token.startswith("\"") and token.endswith("\""):
+        return token[1:-1]
+    if token.startswith("'") and token.endswith("'"):
+        return token[1:-1]
+    lowered = token.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+    if lowered == "null":
+        return None
+    # try integer
+    try:
+        return int(token)
+    except ValueError:
+        pass
+    # try float
+    try:
+        return float(token)
+    except ValueError:
+        pass
+    return token
+
+
+def _parse_key(token: str) -> str:
+    token = token.strip()
+    if token.startswith("\"") and token.endswith("\""):
+        return token[1:-1]
+    if token.startswith("'") and token.endswith("'"):
+        return token[1:-1]
+    return token
+
+
+def _split_key_value(line: str) -> tuple[str, str]:
+    in_single = False
+    in_double = False
+    for index, char in enumerate(line):
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif char == ":" and not in_single and not in_double:
+            return line[:index], line[index + 1 :]
+    raise ValueError(f"Unable to split mapping entry: {line}")
+
+
+class Config:
+    """Convenience wrapper that exposes strongly-typed config sections."""
+
+    def __init__(self, config_file: Any):
+        self._path = Path(config_file)
+        self._raw = load_config(self._path)
+        self._agent = self._parse_agent(self._raw.get("agent", {}))
+        self._tools = self._parse_tools(self._raw.get("tools", {}))
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def raw(self) -> Dict[str, Any]:
+        return dict(self._raw)
+
+    @property
+    def agent(self) -> AgentSettings:
+        return self._agent
+
+    @property
+    def tools(self) -> Dict[str, ToolSettings]:
+        return dict(self._tools)
+
+    def get_tool_settings(self, tool_name: str) -> ToolSettings:
+        try:
+            return self._tools[tool_name]
+        except KeyError as exc:
+            raise KeyError(f"Unknown tool '{tool_name}' referenced in plan") from exc
+
+    def plan(self) -> List[Mapping[str, Any]]:
+        return list(self._agent.plan)
+
+    @staticmethod
+    def _parse_agent(data: Mapping[str, Any]) -> AgentSettings:
+        if not data:
+            raise ValueError("Configuration is missing the 'agent' section")
+
+        llm_data = data.get("llm") or {}
+        if "provider" not in llm_data or "model" not in llm_data:
+            raise ValueError("Agent configuration must include llm.provider and llm.model")
+
+        llm = LLMConfig(
+            provider=str(llm_data["provider"]),
+            model=str(llm_data["model"]),
+            parameters=dict(llm_data.get("parameters", {})),
+        )
+
+        tools = list(data.get("tools", []))
+        plan = [dict(step) for step in data.get("plan", [])]
+        name = str(data.get("name", "Agent"))
+        return AgentSettings(name=name, llm=llm, tools=tools, plan=plan)
+
+    @staticmethod
+    def _parse_tools(data: Mapping[str, Any]) -> Dict[str, ToolSettings]:
+        tools: Dict[str, ToolSettings] = {}
+        for name, definition in data.items():
+            if not isinstance(definition, Mapping):
+                raise ValueError(f"Tool definition for '{name}' must be a mapping")
+            class_path = definition.get("class")
+            if not class_path:
+                raise ValueError(f"Tool '{name}' is missing a 'class' entry")
+            args = definition.get("args", {})
+            if not isinstance(args, Mapping):
+                raise ValueError(f"Tool '{name}' args must be a mapping")
+            tools[name] = ToolSettings(class_path=str(class_path), args=dict(args))
+        return tools

--- a/agentic_framework/examples/max_cut.py
+++ b/agentic_framework/examples/max_cut.py
@@ -1,0 +1,16 @@
+"""Example demonstrating the quantum tool with a Bell-state circuit."""
+
+from pathlib import Path
+
+from agentic_framework import Agent
+
+
+def main() -> None:
+    config_path = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "sample_config.yaml"
+    agent = Agent(config_path)
+    result = agent.run(goal="optimise max-cut instance")
+    print(result["reflection"]["summary"])  # pragma: no cover - demo output
+
+
+if __name__ == "__main__":
+    main()

--- a/agentic_framework/examples/rag.py
+++ b/agentic_framework/examples/rag.py
@@ -1,0 +1,19 @@
+"""Example showcasing retrieval augmented generation orchestration."""
+
+from pathlib import Path
+
+from agentic_framework import Agent
+
+
+def main() -> None:
+    config_path = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "sample_config.yaml"
+    agent = Agent(config_path)
+    result = agent.run(goal="summarise regional services")
+    for step in result["results"]:
+        if step["tool"] == "rag":
+            print(step["output"])  # pragma: no cover - demo output
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/agentic_framework/examples/sql.py
+++ b/agentic_framework/examples/sql.py
@@ -1,0 +1,19 @@
+"""Example showing SQL tool usage inside the executor."""
+
+from pathlib import Path
+
+from agentic_framework import Agent
+
+
+def main() -> None:
+    config_path = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "sample_config.yaml"
+    agent = Agent(config_path)
+    result = agent.run(goal="list enrolled clients")
+    for step in result["results"]:
+        if step["tool"] == "sql":
+            print(step["output"])  # pragma: no cover - demo output
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/agentic_framework/executor.py
+++ b/agentic_framework/executor.py
@@ -1,0 +1,46 @@
+"""Executor responsible for running tools defined in the plan."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, Iterable, List
+
+from .config import Config
+from .tools import ToolRegistry
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Executor:
+    """Execute a plan by resolving tools from the registry."""
+
+    def __init__(self, config: Config):
+        self._config = config
+        self._registry = ToolRegistry(config)
+
+    def execute(self, plan: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Execute every step in the plan and return structured results."""
+
+        results: List[Dict[str, Any]] = []
+        for index, step in enumerate(plan):
+            tool_name = step.get("tool")
+            if not tool_name:
+                raise ValueError(f"Step {index} is missing the 'tool' field: {step}")
+
+            args = step.get("args", {})
+            LOGGER.debug("Executing step %s with tool '%s'", index, tool_name)
+            tool = self._registry.get(tool_name)
+            started = time.perf_counter()
+            output = tool.execute(**args)
+            duration = time.perf_counter() - started
+            LOGGER.debug("Tool '%s' finished in %.4fs", tool_name, duration)
+            results.append(
+                {
+                    "tool": tool_name,
+                    "args": dict(args),
+                    "output": output,
+                    "duration": duration,
+                }
+            )
+        return results

--- a/agentic_framework/planner.py
+++ b/agentic_framework/planner.py
@@ -1,0 +1,28 @@
+"""Simple planner implementation for the scaffold."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .config import Config
+
+
+class Planner:
+    """Planner that materialises a LangGraph-style plan from configuration."""
+
+    def __init__(self, config: Config):
+        self._config = config
+
+    def generate_plan(self, goal: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Return a list of tool invocations.
+
+        If the configuration provides an explicit plan the planner returns a
+        deep copy of those steps. Otherwise it falls back to a simple heuristic
+        that invokes each configured tool once with empty arguments.
+        """
+
+        configured_plan = self._config.plan()
+        if configured_plan:
+            return [dict(step) for step in configured_plan]
+
+        return [{"tool": tool_name, "args": {}} for tool_name in self._config.agent.tools]

--- a/agentic_framework/reflect.py
+++ b/agentic_framework/reflect.py
@@ -1,0 +1,38 @@
+"""Reflection utilities to analyse execution traces."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+from .config import Config
+
+
+class Reflector:
+    """Derive lightweight insights from executed steps."""
+
+    def __init__(self, config: Config):
+        self._config = config
+
+    def reflect_on_execution(
+        self, plan: Iterable[Dict[str, Any]], results: Iterable[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """Summarise execution metadata for downstream evaluation."""
+
+        plan_steps = list(plan)
+        executed_steps = list(results)
+        total_duration = sum(step.get("duration", 0.0) for step in executed_steps)
+        tools_used = [step.get("tool") for step in executed_steps]
+        summary = {
+            "total_steps": len(executed_steps),
+            "tools_used": tools_used,
+            "total_duration": total_duration,
+            "successful": len(plan_steps) == len(executed_steps),
+        }
+        if tools_used:
+            summary["summary"] = (
+                f"Executed {len(tools_used)} steps using {', '.join(tools_used)} "
+                f"in {total_duration:.4f} seconds."
+            )
+        else:
+            summary["summary"] = "No steps executed."
+        return summary

--- a/agentic_framework/tests/__init__.py
+++ b/agentic_framework/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the agentic framework scaffold."""

--- a/agentic_framework/tests/fixtures/sample_config.yaml
+++ b/agentic_framework/tests/fixtures/sample_config.yaml
@@ -1,0 +1,55 @@
+agent:
+  name: TestAgent
+  llm:
+    provider: ibm
+    model: granite-base
+    parameters:
+      temperature: 0.1
+  tools:
+    - http
+    - sql
+    - rag
+    - quantum
+  plan:
+    - tool: http
+      args:
+        url: "/status"
+    - tool: sql
+      args:
+        query: "SELECT name FROM users"
+    - tool: rag
+      args:
+        query: "cybersecurity"
+        top_k: 2
+    - tool: quantum
+      args:
+        circuit: bell
+        shots: 10
+
+tools:
+  http:
+    class: agentic_framework.tools.HTTPTool
+    args:
+      base_url: "https://irondillo.example"
+      canned_responses:
+        "https://irondillo.example/status": "ok"
+  sql:
+    class: agentic_framework.tools.SQLTool
+    args:
+      setup:
+        - "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)"
+        - "INSERT INTO users (name) VALUES ('Alice')"
+        - "INSERT INTO users (name) VALUES ('Bob')"
+  rag:
+    class: agentic_framework.tools.RAGTool
+    args:
+      documents:
+        - id: 1
+          text: "Veteran-owned cybersecurity in East Texas"
+        - id: 2
+          text: "Serving Lindale and Tyler businesses"
+  quantum:
+    class: agentic_framework.tools.QuantumTool
+    args:
+      shots: 10
+      circuit: bell

--- a/agentic_framework/tests/test_agent.py
+++ b/agentic_framework/tests/test_agent.py
@@ -1,0 +1,21 @@
+import unittest
+from pathlib import Path
+
+from agentic_framework.agent import Agent
+
+
+class AgentTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.config_path = Path(__file__).parent / "fixtures" / "sample_config.yaml"
+
+    def test_agent_run_returns_outputs(self):
+        agent = Agent(self.config_path)
+        result = agent.run(goal="assess posture")
+        self.assertIn("plan", result)
+        self.assertIn("results", result)
+        self.assertIn("reflection", result)
+        self.assertEqual(len(result["plan"]), len(result["results"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agentic_framework/tests/test_config.py
+++ b/agentic_framework/tests/test_config.py
@@ -1,0 +1,33 @@
+import unittest
+from pathlib import Path
+
+from agentic_framework.config import AgentSettings, Config, LLMConfig, ToolSettings
+
+
+class ConfigTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.config_path = Path(__file__).parent / "fixtures" / "sample_config.yaml"
+        self.config = Config(self.config_path)
+
+    def test_agent_metadata_loaded(self):
+        agent = self.config.agent
+        self.assertIsInstance(agent, AgentSettings)
+        self.assertEqual(agent.name, "TestAgent")
+        self.assertEqual(agent.llm.provider, "ibm")
+        self.assertEqual(agent.llm.model, "granite-base")
+        self.assertIn("http", agent.tools)
+
+    def test_tool_settings_loaded(self):
+        tools = self.config.tools
+        self.assertIn("sql", tools)
+        self.assertIsInstance(tools["sql"], ToolSettings)
+        self.assertEqual(tools["sql"].class_path, "agentic_framework.tools.SQLTool")
+
+    def test_plan_roundtrip(self):
+        plan = self.config.plan()
+        self.assertEqual(len(plan), 4)
+        self.assertEqual(plan[0]["tool"], "http")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agentic_framework/tests/test_executor.py
+++ b/agentic_framework/tests/test_executor.py
@@ -1,0 +1,34 @@
+import unittest
+from pathlib import Path
+
+from agentic_framework.config import Config
+from agentic_framework.executor import Executor
+from agentic_framework.planner import Planner
+
+
+class ExecutorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        config_path = Path(__file__).parent / "fixtures" / "sample_config.yaml"
+        self.config = Config(config_path)
+        self.planner = Planner(self.config)
+        self.executor = Executor(self.config)
+
+    def test_execute_plan(self):
+        plan = self.planner.generate_plan()
+        results = self.executor.execute(plan)
+        self.assertEqual(len(results), len(plan))
+        http_result = results[0]
+        self.assertEqual(http_result["output"]["body"], "ok")
+        sql_result = results[1]
+        self.assertEqual(sql_result["output"]["rowcount"], 2)
+
+    def test_execution_records_duration(self):
+        plan = self.planner.generate_plan()
+        results = self.executor.execute(plan)
+        for result in results:
+            self.assertIn("duration", result)
+            self.assertGreaterEqual(result["duration"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agentic_framework/tests/test_planner.py
+++ b/agentic_framework/tests/test_planner.py
@@ -1,0 +1,27 @@
+import unittest
+from pathlib import Path
+
+from agentic_framework.config import Config
+from agentic_framework.planner import Planner
+
+
+class PlannerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        config_path = Path(__file__).parent / "fixtures" / "sample_config.yaml"
+        self.config = Config(config_path)
+        self.planner = Planner(self.config)
+
+    def test_generate_plan_from_config(self):
+        plan = self.planner.generate_plan()
+        self.assertEqual(len(plan), 4)
+        self.assertEqual(plan[1]["tool"], "sql")
+        self.assertIn("args", plan[1])
+
+    def test_generate_plan_goal_passthrough(self):
+        # The default planner ignores the goal but should not error.
+        plan = self.planner.generate_plan(goal="investigate logs")
+        self.assertEqual(len(plan), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agentic_framework/tests/test_reflect.py
+++ b/agentic_framework/tests/test_reflect.py
@@ -1,0 +1,28 @@
+import unittest
+from pathlib import Path
+
+from agentic_framework.config import Config
+from agentic_framework.executor import Executor
+from agentic_framework.planner import Planner
+from agentic_framework.reflect import Reflector
+
+
+class ReflectorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        config_path = Path(__file__).parent / "fixtures" / "sample_config.yaml"
+        self.config = Config(config_path)
+        self.planner = Planner(self.config)
+        self.executor = Executor(self.config)
+        self.reflector = Reflector(self.config)
+
+    def test_reflection_summary(self):
+        plan = self.planner.generate_plan()
+        results = self.executor.execute(plan)
+        summary = self.reflector.reflect_on_execution(plan, results)
+        self.assertEqual(summary["total_steps"], len(plan))
+        self.assertTrue(summary["successful"])
+        self.assertIn("Executed", summary["summary"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agentic_framework/tools.py
+++ b/agentic_framework/tools.py
@@ -1,0 +1,196 @@
+"""Tool registry and built-in tool implementations."""
+
+from __future__ import annotations
+
+import importlib
+import math
+import sqlite3
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+from .config import Config
+
+try:  # pragma: no cover - optional dependency
+    from qiskit import Aer, QuantumCircuit, execute
+except Exception:  # pragma: no cover - gracefully degrade if qiskit is absent
+    Aer = None
+    QuantumCircuit = None
+
+    def execute(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("qiskit is not available in this environment")
+
+
+class ToolRegistry:
+    """Instantiate and cache tools defined in the configuration."""
+
+    def __init__(self, config: Config):
+        self._config = config
+        self._instances: Dict[str, BaseTool] = {}
+
+    def get(self, name: str) -> "BaseTool":
+        if name not in self._instances:
+            settings = self._config.get_tool_settings(name)
+            tool_cls = resolve_tool_class(settings.class_path)
+            kwargs = dict(settings.args)
+            self._instances[name] = tool_cls(name=name, **kwargs)
+        return self._instances[name]
+
+
+def resolve_tool_class(class_path: str):
+    module_name, _, cls_name = class_path.rpartition(".")
+    if not module_name:
+        raise ValueError(f"Invalid class path '{class_path}'")
+    module = importlib.import_module(module_name)
+    return getattr(module, cls_name)
+
+
+def get_tool(class_path: str, name: str, **kwargs: Any) -> "BaseTool":
+    tool_cls = resolve_tool_class(class_path)
+    return tool_cls(name=name, **kwargs)
+
+
+@dataclass
+class BaseTool:
+    """Base class for tools with a consistent execute contract."""
+
+    name: str
+
+    def execute(self, **_kwargs: Any) -> Any:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class HTTPTool(BaseTool):
+    """Minimal HTTP abstraction using canned responses for determinism."""
+
+    def __init__(
+        self,
+        name: str,
+        base_url: str = "",
+        canned_responses: Optional[Mapping[str, Any]] = None,
+    ):
+        super().__init__(name=name)
+        self.base_url = base_url.rstrip("/")
+        self.canned_responses = dict(canned_responses or {})
+
+    def execute(
+        self,
+        url: str,
+        method: str = "GET",
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        target = self._normalise_url(url)
+        body = self.canned_responses.get(target)
+        if body is None:
+            body = f"{method.upper()} {target}"
+        return {
+            "url": target,
+            "method": method.upper(),
+            "params": dict(params or {}),
+            "body": body,
+        }
+
+    def _normalise_url(self, url: str) -> str:
+        if url.startswith("http"):
+            return url
+        if not self.base_url:
+            return url
+        return f"{self.base_url}/{url.lstrip('/')}"
+
+
+class SQLTool(BaseTool):
+    """In-memory SQLite tool suitable for deterministic tests."""
+
+    def __init__(self, name: str, setup: Optional[Sequence[str]] = None):
+        super().__init__(name=name)
+        self._connection = sqlite3.connect(":memory:")
+        self._connection.row_factory = sqlite3.Row
+        if setup:
+            cursor = self._connection.cursor()
+            for statement in setup:
+                cursor.execute(statement)
+            self._connection.commit()
+
+    def execute(
+        self, query: str, parameters: Optional[Sequence[Any]] = None
+    ) -> Dict[str, Any]:
+        cursor = self._connection.cursor()
+        cursor.execute(query, parameters or [])
+        if query.lstrip().upper().startswith("SELECT"):
+            rows = [dict(row) for row in cursor.fetchall()]
+            return {"rows": rows, "rowcount": len(rows)}
+        self._connection.commit()
+        return {"rowcount": cursor.rowcount}
+
+
+class RAGTool(BaseTool):
+    """Toy retrieval-augmented generation helper using keyword matching."""
+
+    def __init__(
+        self,
+        name: str,
+        documents: Optional[Iterable[Mapping[str, str]]] = None,
+    ):
+        super().__init__(name=name)
+        self._documents = [dict(doc) for doc in documents or []]
+
+    def execute(self, query: str, top_k: int = 1) -> Dict[str, Any]:
+        scored = []
+        tokens = self._tokenise(query)
+        for doc in self._documents:
+            score = self._score(tokens, self._tokenise(doc.get("text", "")))
+            scored.append((score, doc))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        top_results = [doc for score, doc in scored[:top_k] if score > 0]
+        return {"query": query, "results": top_results}
+
+    @staticmethod
+    def _tokenise(text: str) -> List[str]:
+        return [token.lower() for token in text.split() if token]
+
+    @staticmethod
+    def _score(query_tokens: Iterable[str], doc_tokens: Iterable[str]) -> float:
+        query_set = set(query_tokens)
+        if not query_set:
+            return 0.0
+        doc_set = set(doc_tokens)
+        intersection = query_set & doc_set
+        if not intersection:
+            return 0.0
+        return len(intersection) / math.sqrt(len(query_set) * len(doc_set) or 1)
+
+
+class QuantumTool(BaseTool):
+    """Wrapper around qiskit with a graceful fallback when unavailable."""
+
+    def __init__(self, name: str, shots: int = 1024, circuit: Optional[Any] = None):
+        super().__init__(name=name)
+        self.shots = shots
+        self.default_circuit = circuit or "bell"
+
+    def execute(
+        self, circuit: Optional[Any] = None, shots: Optional[int] = None
+    ) -> Dict[str, Any]:
+        circuit = circuit or self.default_circuit
+        shots = shots or self.shots
+        if QuantumCircuit is None:
+            return {"counts": {"00": shots}, "backend": "fallback"}
+
+        qc = self._ensure_circuit(circuit)
+        backend = Aer.get_backend("aer_simulator")
+        job = execute(qc, backend, shots=shots)
+        result = job.result()
+        counts = result.get_counts()
+        return {"counts": counts, "backend": backend.name()}
+
+    def _ensure_circuit(self, circuit: Any) -> "QuantumCircuit":
+        if isinstance(circuit, QuantumCircuit):
+            return circuit
+        if isinstance(circuit, str):
+            if circuit == "bell":
+                qc = QuantumCircuit(2, 2)
+                qc.h(0)
+                qc.cx(0, 1)
+                qc.measure([0, 1], [0, 1])
+                return qc
+            raise ValueError(f"Unknown circuit template '{circuit}'")
+        raise TypeError("Circuit must be a QuantumCircuit instance or template name")

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,54 @@
+agent:
+  name: Iron Dillo Agent
+  llm:
+    provider: ibm
+    model: granite-13b-chat-v2
+    parameters:
+      temperature: 0.1
+  tools:
+    - http
+    - sql
+    - rag
+    - quantum
+  plan:
+    - tool: http
+      args:
+        url: "/status"
+    - tool: sql
+      args:
+        query: "SELECT name FROM users"
+    - tool: rag
+      args:
+        query: "cybersecurity for Tyler"
+        top_k: 2
+    - tool: quantum
+      args:
+        circuit: bell
+
+tools:
+  http:
+    class: agentic_framework.tools.HTTPTool
+    args:
+      base_url: "https://irondillo.example"
+      canned_responses:
+        "https://irondillo.example/status": "healthy"
+  sql:
+    class: agentic_framework.tools.SQLTool
+    args:
+      setup:
+        - "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)"
+        - "INSERT INTO users (name) VALUES ('Lindale Services')"
+        - "INSERT INTO users (name) VALUES ('Tyler Manufacturing')"
+  rag:
+    class: agentic_framework.tools.RAGTool
+    args:
+      documents:
+        - id: 1
+          text: "Veteran-owned cybersecurity partner for Lindale and Tyler"
+        - id: 2
+          text: "Protecting East Texas rural operations with managed detection"
+  quantum:
+    class: agentic_framework.tools.QuantumTool
+    args:
+      shots: 32
+      circuit: bell

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+qiskit>=0.44.0; extra == "quantum"


### PR DESCRIPTION
## Summary
- build a configuration loader with YAML fallback along with agent, planner, executor, and reflector orchestration components
- add a tool registry plus HTTP, SQL, RAG, and Quantum tool implementations with sample configurations and runnable examples
- provide comprehensive unit tests, documentation updates, requirements, and gitignore entries to support the scaffold

## Testing
- python -m unittest discover -s agentic_framework/tests

------
https://chatgpt.com/codex/tasks/task_e_68d405d4cbc0832288d7c57fc6c2d00e