### PR TITLE
Remove Iron Dillo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ extensible tool registry, and deterministic fixtures for testing.
 
 ```yaml
 agent:
-  name: Iron Dillo Agent
+  name: Industry Challenge Agent
   llm:
     provider: ibm
     model: granite-13b-chat-v2

--- a/agentic_framework/tests/fixtures/sample_config.yaml
+++ b/agentic_framework/tests/fixtures/sample_config.yaml
@@ -30,9 +30,9 @@ tools:
   http:
     class: agentic_framework.tools.HTTPTool
     args:
-      base_url: "https://irondillo.example"
+      base_url: "https://industry-challenge.example"
       canned_responses:
-        "https://irondillo.example/status": "ok"
+        "https://industry-challenge.example/status": "ok"
   sql:
     class: agentic_framework.tools.SQLTool
     args:

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 agent:
-  name: Iron Dillo Agent
+  name: Industry Challenge Agent
   llm:
     provider: ibm
     model: granite-13b-chat-v2
@@ -29,9 +29,9 @@ tools:
   http:
     class: agentic_framework.tools.HTTPTool
     args:
-      base_url: "https://irondillo.example"
+      base_url: "https://industry-challenge.example"
       canned_responses:
-        "https://irondillo.example/status": "healthy"
+        "https://industry-challenge.example/status": "healthy"
   sql:
     class: agentic_framework.tools.SQLTool
     args:


### PR DESCRIPTION
## Summary
- update configuration example and default agent name to remove the Iron Dillo reference

## Testing
- python -m unittest discover -s agentic_framework/tests

------
https://chatgpt.com/codex/tasks/task_e_68d408f4360c8322a1d91df467901c5e