### PR TITLE
Add Python-focused .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,66 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+venv/
+ENV/
+env/
+.venv/
+
+# Jupyter notebooks checkpoints
+.ipynb_checkpoints
+
+# IDE settings
+.vscode/
+.idea/
+*.swp
+
+# Local data / caches
+*.log
+*.sqlite3
+*.db
+*.DS_Store
+*.pkl
+*.bak
+.cache/
+.mypy_cache/
+.pytest_cache/
+__snapshots__/
+
+# Coverage / testing
+.coverage
+.tox/
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+
+# OS-specific
+Thumbs.db
+.DS_Store


### PR DESCRIPTION
## Summary
- add a .gitignore file to filter out Python build artifacts, environments, and local cache files

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d40789a6cc8322b565b7937a172179