### PR TITLE
Tidy repo metadata and refresh README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ env/
 *.log
 *.sqlite3
 *.db
-*.DS_Store
 *.pkl
 *.bak
 .cache/
@@ -65,7 +64,4 @@ coverage.xml
 # OS-specific
 Thumbs.db
 .DS_Store
-=======
-__pycache__/
-*.py[cod]
 

--- a/README.md
+++ b/README.md
@@ -1,51 +1,70 @@
 # Agnostic Agent Framework
 
-A minimal-yet-complete scaffold for building agentic workflows. The project
-ships with a configuration driven planner → executor → reflector loop, an
-extensible tool registry, and deterministic fixtures for testing.
+A minimal yet complete scaffold for experimenting with agentic workflows. The
+framework exposes a configuration driven planner → executor → reflector loop,
+an extensible tool registry, and deterministic fixtures for testing so that new
+ideas can be validated quickly.
 
-## Features
+## Highlights
 
-- **Model/provider agnostic.** Configuration specifies the LLM provider,
-  model, and parameters without code changes.
-- **Config-driven orchestration.** Plans and tool wiring live in YAML, making it
-  easy to swap domains or experiment with new flows.
-- **Tool-centric execution.** Built-in HTTP, SQL, RAG, and Quantum tools
-  demonstrate how to compose external capabilities while keeping tests fast.
-- **LangGraph-style loop.** Planner emits a step list, executor streams through
-  tools, and the reflector summarises the run for evaluation or logging.
-- **Observability aware.** Execution captures per-step timings for lightweight
-  performance tracking.
-- **Fully tested.** The repository includes a unittest harness and fixture
-  configuration for deterministic validation.
+- **Model/provider agnostic.** The YAML configuration specifies the LLM
+  provider, model, and parameters—no code edits required.
+- **Config-first orchestration.** Plans, tool wiring, and runtime defaults live
+  in `config.yaml`, making it easy to swap domains or prototype new flows.
+- **Batteries included tools.** HTTP, SQL, RAG, quantum, and Docling document
+  parsing tools demonstrate how to compose external capabilities while keeping
+  the suite deterministic.
+- **LangGraph-style loop.** The planner emits step lists, the executor streams
+  through tools, and the reflector summarises each run for lightweight
+  observability.
+- **Fully tested.** A unittest harness with canned fixtures ensures changes are
+  regression safe.
 
-## Quick start
+## Repository layout
 
-1. Install dependencies:
+```
+agentic_framework/
+├── agent.py            # High-level façade that wires planner/executor/reflector
+├── config.py           # YAML loader with a minimal fallback parser
+├── executor.py         # Streams through plan steps, timing each tool call
+├── planner.py          # Materialises plans from configuration
+├── reflect.py          # Summarises execution results
+├── tools.py            # Built-in tool implementations + registry helpers
+└── tests/              # Deterministic unit tests & fixtures
+```
+
+Additional examples live in `agentic_framework/examples/` and can be run
+directly via `python -m ...`.
+
+## Getting started
+
+1. **Install dependencies**
 
    ```bash
    pip install -r requirements.txt
    ```
 
-2. Review or edit `config.yaml` to describe your domain. Tool definitions accept
+2. **Review the configuration**
+
+   Update `config.yaml` to describe your domain. Tool definitions accept
    fully-qualified class paths and optional constructor arguments.
 
-3. Run an agent loop:
+3. **Run an example loop**
 
    ```bash
    python -m agentic_framework.examples.sql
    ```
 
-   Each example points at the sample fixture configuration to keep output
+   Each example references the sample fixture configuration to keep output
    deterministic. Swap in your own configuration path for real workloads.
 
-4. Execute the full test suite:
+4. **Execute the test suite**
 
    ```bash
    python -m unittest discover -s agentic_framework/tests
    ```
 
-## Configuration shape
+## Configuration primer
 
 ```yaml
 agent:
@@ -60,6 +79,7 @@ agent:
     - sql
     - rag
     - quantum
+    - docling
   plan:
     - tool: http
       args:
@@ -77,18 +97,24 @@ agent:
 ```
 
 Each tool referenced in `plan` must have a matching entry under `tools`. The
-framework resolves the class dynamically and caches the instance across steps.
+framework resolves tool classes dynamically and caches instances across steps.
 
-## Adding new tools
+### Adding new tools
 
 1. Implement a subclass of `BaseTool` with an `execute` method.
-2. Expose it via a fully-qualified path (for example
-   `my_package.tools.CustomTool`).
+2. Expose it via a fully-qualified path (for example `my_package.tools.CustomTool`).
 3. Update the YAML configuration with the tool definition and any constructor
    arguments.
 
 The executor will automatically resolve the class the next time a plan step
 references the tool.
+
+### Docling integration
+
+The optional `DoclingTool` enriches document parsing when the
+[Docling](https://github.com/docling-project/docling) dependency is installed.
+Without Docling the tool falls back to deterministic chunking so tests remain
+hermetic. See [README_DOCILING.md](README_DOCILING.md) for usage details.
 
 ## License
 


### PR DESCRIPTION
## Summary
- clean up the repository `.gitignore` by removing the stray merge artifact and duplicate ignore rules
- refresh the main README with repository layout, clearer onboarding steps, and a note about the Docling integration

## Testing
- python -m unittest discover -s agentic_framework/tests

------
https://chatgpt.com/codex/tasks/task_e_68d431819d7883229d2b4b7033b35c97